### PR TITLE
US21081 - Add attachments to SendAnonymousEmailRequest

### DIFF
--- a/recom_api/recom_api.proto
+++ b/recom_api/recom_api.proto
@@ -131,6 +131,14 @@ message SendAnonymousEmailRequest {
   string fromEmailPrefix = 12;
   string fromEmailDisplayName = 13;
   google.protobuf.StringValue context_chain_id = 14;
+  repeated EmailAttachmentInput attachments = 15;
+}
+
+message EmailAttachmentInput {
+  bytes content = 1;
+  string file_name = 2;
+  string content_type = 3;
+  string content_id = 4;
 }
 
 message SendMessageRequest {


### PR DESCRIPTION
Adds optional repeated EmailAttachmentInput field on the anonymous email request so the energy-provider referral can fall back to anonymous send when the responsible agent has no primary email extension account, without losing the signed POA PDF attachments.

Empty list = identical behavior to existing callers (signing-order invites), so this is a purely additive change.